### PR TITLE
Ignore custom property sets

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "mocha": "^3.0.1"
   },
   "dependencies": {
+    "lodash": "^4.17.4",
     "postcss": "^6.0.0",
     "postcss-selector-parser": "^2.2.3"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import postcss from 'postcss';
 import parser from 'postcss-selector-parser';
+import { get } from 'lodash';
 
 function nodeIsInsensitiveAttribute(node) {
 	return node.type === 'attribute' && node.insensitive;
@@ -82,8 +83,17 @@ function transform(selectors) {
 	}
 }
 
+function cssRuleHasSelectorEndingWithColon(rule) {
+	const selector = get(rule, 'raws.selector.raw', rule.selector);
+	return selector[selector.length - 1] === ':';
+}
+
 export default postcss.plugin('postcss-attribute-case-insensitive', () => css => {
 	css.walkRules(rule => {
+		if (cssRuleHasSelectorEndingWithColon(rule)) {
+			return;
+		}
+
 		rule.selector = parser(transform).process(rule.selector).result;
 	});
 });


### PR DESCRIPTION
Fixes @apply causes `Expected pseudo-class or pseudo-element`

I encountered this issue when using postcss-cssnext to process some polymer components.

Based on the suggestion in https://github.com/MoOx/postcss-cssnext/issues/371 I looked at this dependency. I adapted the solution used in https://github.com/stylelint/stylelint/pull/804 and applied it here.

