### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "mocha": "^3.0.1"
   },
   "dependencies": {
-    "postcss": "^6.0.0",
-    "postcss-selector-parser": "^2.2.3"
+    "postcss": "^6.0.22",
+    "postcss-selector-parser": "^4.0.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -29,12 +29,15 @@ function createSensitiveAtributes(attribute) {
 	const attributes = transformString([''], 0, attribute.value);
 	return attributes.map(x => {
 		const newAttribute = attribute.clone({
-			value: x,
-			insensitive: false,
-			raws: {
-				insensitive: ''
-			}
+			spaces: {
+				after: attribute.spaces.after,
+				before: attribute.spaces.before
+			},
+			insensitive: false
 		});
+
+		newAttribute.setValue(x);
+
 		return newAttribute;
 	});
 }
@@ -84,6 +87,6 @@ function transform(selectors) {
 
 export default postcss.plugin('postcss-attribute-case-insensitive', () => css => {
 	css.walkRules(rule => {
-		rule.selector = parser(transform).process(rule.selector).result;
+		rule.selector = parser(transform).processSync(rule.selector);
 	});
 });


### PR DESCRIPTION
- Update: postcss-selector-parser v4 (major)
- Update: postcss (patch)

I’d like to get the selector parsers in alignment for postcss-preset-env:

```
postcss-preset-env@4.1.0
├─┬ postcss-attribute-case-insensitive@2.0.0
│ └── postcss-selector-parser@2.2.3
├─┬ postcss-dir-pseudo-class@4.0.0
│ └── postcss-selector-parser@4.0.0
└─┬ postcss-pseudo-class-any-link@5.0.0
  └── postcss-selector-parser@4.0.0
```